### PR TITLE
Update the pin mappins in Sd2PinMap.h for the Papilio Duo, and add ma…

### DIFF
--- a/libraries/SD/SD.cpp
+++ b/libraries/SD/SD.cpp
@@ -346,6 +346,8 @@ boolean SDClass::begin(uint8_t csPin) {
          root.openRoot(&volume);
 }
 
+#ifdef ZPU
+
 boolean SDClass::begin(uint8_t csPin, uint8_t wishboneSlot) {
   /*
 
@@ -360,6 +362,8 @@ boolean SDClass::begin(uint8_t csPin, uint8_t wishboneSlot) {
          ( volume.init(card) || volume.init(card,1)) &&
         root.openRoot(&volume);
 }
+
+#endif
 
 // this little helper is used to traverse paths
 SdFile SDClass::getParentDir(const char *filepath, int *index) {

--- a/libraries/SD/examples/CardInfo/CardInfo.ino
+++ b/libraries/SD/examples/CardInfo/CardInfo.ino
@@ -26,7 +26,6 @@
 #define CSPIN  WING_CL4
 #define WISHBONESLOT 12
 
-
 // set up variables using the SD utility library functions:
 Sd2Card card;
 SdVolume volume;
@@ -44,7 +43,11 @@ void setup()
 
   // we'll use the initialization code from the utility libraries
   // since we're just testing if the card is working!
+#ifdef ZPU
   if (!card.init(SPI_HALF_SPEED, CSPIN, WISHBONESLOT)) {
+#else
+  if (!card.init(SPI_HALF_SPEED, CSPIN)) {
+#endif
     Serial.println("initialization failed. Things to check:");
     Serial.println("* is a card is inserted?");
     Serial.println("* Is your wiring correct?");

--- a/libraries/SD/utility/Sd2Card.cpp
+++ b/libraries/SD/utility/Sd2Card.cpp
@@ -411,7 +411,9 @@ void Sd2Card::partialBlockRead(uint8_t value) {
  * the value zero, false, is returned for failure.
  */
 int Sd2Card::readBlock(uint32_t block, uint8_t* dst) {
-	//return readData(block, 0, 512, dst);
+#ifdef AVR
+  return readData(block, 0, 512, dst);
+#else
 	unsigned int *idst;
 	int i;
 
@@ -447,7 +449,8 @@ int Sd2Card::readBlock(uint32_t block, uint8_t* dst) {
 
 fail:
 	chipSelectHigh();
-	return false;
+  return false;
+#endif
 }
 //------------------------------------------------------------------------------
 /**
@@ -462,7 +465,7 @@ fail:
  */
 int Sd2Card::readData(uint32_t block,
 					  unsigned offset, unsigned count, uint8_t* dst) {
-//	unsigned n;
+	unsigned n;
 	if (count == 0) return true;
 	if ((count + offset) > 512) {
 		goto fail;

--- a/libraries/SD/utility/Sd2Card.h
+++ b/libraries/SD/utility/Sd2Card.h
@@ -52,6 +52,15 @@ uint8_t const SPI_QUARTER_SPEED = 2;
 #define SOFTWARE_SPI
 #endif  // MEGA_SOFT_SPI
 
+/**
+ * Define MEGA_SOFT_SPI non-zero to use software SPI on the hardware ATMega32U4
+ * on Papilio DUO connected to a Classic Computing Shield. The SD card pins on the
+ * shield are not connected to the hardware SPI pins.
+ */
+#if MEGA_SOFT_SPI && (defined(__AVR_ATmega32U4__))
+#define SOFTWARE_SPI
+#endif // MEGA_SOFT_SPI
+
 #if defined(ZPU)
 #undef SOFTWARE_SPI
 #endif // ZPU
@@ -82,20 +91,22 @@ uint8_t const  SPI_SCK_PIN = SCK_PIN;
 /** optimize loops for hardware SPI */
 #ifndef USE_SPI_LIB
 #define OPTIMIZE_HARDWARE_SPI
-#endif
+#endif // USE_SPI_LIB
+
+#endif // AVR
 
 #else  // SOFTWARE_SPI
 // define software SPI pins so Mega can use unmodified GPS Shield
 /** SPI chip select pin */
-uint8_t const SD_CHIP_SELECT_PIN = 10;
+uint8_t const SD_CHIP_SELECT_PIN = 16;
 /** SPI Master Out Slave In pin */
-uint8_t const SPI_MOSI_PIN = 11;
+uint8_t const SPI_MOSI_PIN = 14;
 /** SPI Master In Slave Out pin */
-uint8_t const SPI_MISO_PIN = 12;
+uint8_t const SPI_MISO_PIN = 2;
 /** SPI Clock pin */
-uint8_t const SPI_SCK_PIN = 13;
+uint8_t const SPI_SCK_PIN = 15;
 #endif  // SOFTWARE_SPI
-#endif // AVR
+
 //------------------------------------------------------------------------------
 /** Protect block zero from write if nonzero */
 #define SD_PROTECT_BLOCK_ZERO 1

--- a/libraries/SD/utility/Sd2PinMap.h
+++ b/libraries/SD/utility/Sd2PinMap.h
@@ -187,40 +187,40 @@ static const pin_map_t digitalPinMap[] = {
 // Leonardo
 
 // Two Wire (aka I2C) ports
-uint8_t const SDA_PIN = 2;
-uint8_t const SCL_PIN = 3;
+uint8_t const SDA_PIN = 7;
+uint8_t const SCL_PIN = 8;
 
 // SPI port
-uint8_t const SS_PIN = 17;
-uint8_t const MOSI_PIN = 16;
-uint8_t const MISO_PIN = 14;
+uint8_t const SS_PIN = 16;
+uint8_t const MOSI_PIN = 14;
+uint8_t const MISO_PIN = 2;
 uint8_t const SCK_PIN = 15;
 
 static const pin_map_t digitalPinMap[] = {
   {&DDRD, &PIND, &PORTD, 2},  // D2  0
   {&DDRD, &PIND, &PORTD, 3},  // D3  1
-  {&DDRD, &PIND, &PORTD, 1},  // D1  2
-  {&DDRD, &PIND, &PORTD, 0},  // D0  3
-  {&DDRD, &PIND, &PORTD, 4},  // D4  4
-  {&DDRC, &PINC, &PORTC, 6},  // C6  5
-  {&DDRD, &PIND, &PORTD, 7},  // D7  6
-  {&DDRE, &PINE, &PORTE, 6},  // E6  7
-  {&DDRB, &PINB, &PORTB, 4},  // B4  8
-  {&DDRB, &PINB, &PORTB, 5},  // B5  9
-  {&DDRB, &PINB, &PORTB, 6},  // B6 10
-  {&DDRB, &PINB, &PORTB, 7},  // B7 11
-  {&DDRD, &PIND, &PORTD, 6},  // D6 12
-  {&DDRC, &PINC, &PORTC, 7},  // C7 13
-  {&DDRB, &PINB, &PORTB, 3},  // B3 14
-  {&DDRB, &PINB, &PORTB, 1},  // B1 15
-  {&DDRB, &PINB, &PORTB, 2},  // B2 16
+  {&DDRB, &PINB, &PORTB, 5},  // B5  2
+  {&DDRB, &PINB, &PORTB, 4},  // B4  3
+  {&DDRD, &PIND, &PORTD, 7},  // D7  4
+  {&DDRD, &PIND, &PORTD, 6},  // D6  5
+  {&DDRD, &PIND, &PORTD, 4},  // D4  6
+  {&DDRD, &PIND, &PORTD, 1},  // D1  7
+  {&DDRD, &PIND, &PORTD, 0},  // D0  8
+  {&DDRB, &PINB, &PORTB, 7},  // B7  9
+  {&DDRB, &PINB, &PORTB, 0},  // B0 10
+  {&DDRB, &PINB, &PORTB, 2},  // B2 11
+  {&DDRB, &PINB, &PORTB, 3},  // B3 12
+  {&DDRB, &PINB, &PORTB, 1},  // B1 13
+  {&DDRB, &PINB, &PORTB, 6},  // B6 14
+  {&DDRC, &PINC, &PORTC, 6},  // C6 15
+  {&DDRC, &PINC, &PORTC, 7},  // C7 16
   {&DDRB, &PINB, &PORTB, 0},  // B0 17
-  {&DDRF, &PINF, &PORTF, 7},  // F7 18
-  {&DDRF, &PINF, &PORTF, 6},  // F6 19
-  {&DDRF, &PINF, &PORTF, 5},  // F5 20
-  {&DDRF, &PINF, &PORTF, 4},  // F4 21
-  {&DDRF, &PINF, &PORTF, 1},  // F1 22
-  {&DDRF, &PINF, &PORTF, 0},  // F0 23
+  {&DDRF, &PINF, &PORTF, 0},  // F0 18
+  {&DDRF, &PINF, &PORTF, 1},  // F1 19
+  {&DDRF, &PINF, &PORTF, 4},  // F4 20
+  {&DDRF, &PINF, &PORTF, 5},  // F5 21
+  {&DDRF, &PINF, &PORTF, 6},  // F6 22
+  {&DDRF, &PINF, &PORTF, 7},  // F7 23
 };
 //------------------------------------------------------------------------------
 #elif defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__)


### PR DESCRIPTION
This change enables the SD card library and examples to run on the hardware ATMega32U4 AVR. The pin mappings in Sd2PinMap.h have been updated to the correct pin mappings for the Papilio Duo.

To enable the SD card examples to run on the ATMega32U4 connected to a Classic Computing Shield, a macro define has been added to enable software SPI. This is necessary because the SD slot pins on the shield are not connected to the AVR's hardware SPI pins.